### PR TITLE
Use new api of go-chassis to get circuit breaker status

### DIFF
--- a/csemonitor.go
+++ b/csemonitor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/registry"
-	"github.com/ServiceComb/go-chassis/third_party/forked/afex/hystrix-go/hystrix"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -102,7 +101,11 @@ func (reporter *Reporter) Run() {
 				if len(monitorData.Interfaces) != 0 {
 					count++
 					if count == 10 {
-						hystrix.Flush()
+						reporter.Registry.Each(func(s string, i interface{}) {
+							if c, ok := i.(metrics.Counter); ok {
+								c.Clear()
+							}
+						})
 						count = 0
 					}
 				}

--- a/monitorData.go
+++ b/monitorData.go
@@ -92,11 +92,10 @@ func (monitorData *MonitorData) appendInterfaceInfo(name string, i interface{}) 
 			interfaceInfo.successCount = metric.Count()
 		}
 
-		cb, _, _ := hystrix.GetCircuit(getInterfaceName(name))
-		if cb.IsOpen() {
-			interfaceInfo.IsCircuitBreakerOpen = true
-		} else {
+		if isCBOpen, err := hystrix.IsCircuitBreakerOpen(getInterfaceName(name)); err != nil {
 			interfaceInfo.IsCircuitBreakerOpen = false
+		} else {
+			interfaceInfo.IsCircuitBreakerOpen = isCBOpen
 		}
 
 		qps := (float64(interfaceInfo.Total) * (1 - math.Exp(-5.0/60.0/1)))


### PR DESCRIPTION
Use new api of go-chassis to get circuit breaker status, to prevent uncontrollable increment of goroutine